### PR TITLE
Update rembg_queue_server.py

### DIFF
--- a/rembg_queue_server.py
+++ b/rembg_queue_server.py
@@ -73,7 +73,7 @@ DEFAULT_MODEL_NAME = "birefnet"
 
 # --- GPU Configuration for Rembg ---
 REMBG_USE_GPU = True
-REMBG_PREFERRED_GPU_PROVIDERS = ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'DmlExecutionProvider']
+REMBG_PREFERRED_GPU_PROVIDERS = ['CUDAExecutionProvider', 'DmlExecutionProvider']
 REMBG_CPU_PROVIDERS = ['CPUExecutionProvider']
 
 


### PR DESCRIPTION
The tensorrt EP caused a failure on 7/7 because the EP is not found and it did not fallback to CUDA. Leaving it out is probably best since the EP is not installed